### PR TITLE
Fix on tokens creation for missing IDs and adding minting tests

### DIFF
--- a/eth/contracts/Poap.sol
+++ b/eth/contracts/Poap.sol
@@ -119,7 +119,7 @@ contract Poap is Initializable, ERC721, ERC721Enumerable, PoapRoles, PoapPausabl
         for (uint256 i = 0; i < to.length; ++i) {
             _mintToken(eventId, lastId + 1 + i, to[i]);
         }        
-        lastId += 1 + to.length;
+        lastId += to.length;
         return true;
     }
 
@@ -135,7 +135,7 @@ contract Poap is Initializable, ERC721, ERC721Enumerable, PoapRoles, PoapPausabl
         for (uint256 i = 0; i < eventIds.length; ++i) {
             _mintToken(eventIds[i], lastId + 1 + i, to);
         }        
-        lastId += 1 + eventIds.length;
+        lastId += eventIds.length;
         return true;
     }
 


### PR DESCRIPTION
## Description
- It was noticed that as tokens were minted, the ID didn't increment as expected. As a result, several tokens IDs were not used. Below a screenshot of Etherscan that highlights the missing IDs.
<img width="724" alt="Screenshot" src="https://user-images.githubusercontent.com/12477284/61093476-1a157280-a421-11e9-9ece-9cf86af391fc.png">

## What was the problem?
After testing the `Poap.sol` contract we identified that the missing IDs were appearing as batch minting methods were called. 
We could quickly identify that the methods `mintEventToManyUsers` and `mintUserToManyEvents` were adding an extra token to the `lastId` variable that keeps track of the last token's ID minted.

## Other comments
We also included some test for the token minting methods, so that we could test that the bug was fixed.
Individual tests for each minting method are included in this PR, and also an integration one that tests all methods sequentially and validates the correct creation of the tokens.

<img width="589" alt="Screen Shot 2019-07-11 at 9 27 59 PM" src="https://user-images.githubusercontent.com/12477284/61093845-ce63c880-a422-11e9-806a-e8ea9623f71d.png">


